### PR TITLE
Loading database config bugfix

### DIFF
--- a/libraries/PHPActiveRecord.php
+++ b/libraries/PHPActiveRecord.php
@@ -14,7 +14,7 @@ class PHPActiveRecord {
         $spark_path = dirname(__DIR__).'/';
 
         // Include the CodeIgniter Database File
-        require_once APPPATH.'config/database'.EXT;
+        require APPPATH.'config/database'.EXT;
 
         // Include the ActiveRecord bootstrapper
         require_once $spark_path.'vendor/php-activerecord/ActiveRecord.php';
@@ -24,7 +24,7 @@ class PHPActiveRecord {
 
         if ($db && $active_group)
         {
-            foreach ($db as $conn_name => $conn) 
+            foreach ($db as $conn_name => $conn)
             {
                 // Build the DSN string for each connection
                 $connections[$conn_name] =   $conn['dbdriver'].


### PR DESCRIPTION
Loading the database config should not be "require_once", but "require" when autoloading the normal database class. This otherwise results in an error message.
