### PR TITLE
Fix problem on autoload function with PHP 5.4.3-1

### DIFF
--- a/vendor/php-activerecord/ActiveRecord.php
+++ b/vendor/php-activerecord/ActiveRecord.php
@@ -45,7 +45,7 @@ function activerecord_autoload($class_name)
 	}
 
     $file_name = "{$class_name}.php";
-	$file = $root.DS.$file_name;
+	$file = $root.DS.strtolower($file_name);
 
 	if (file_exists($file)) {
 		require $file;


### PR DESCRIPTION
My production server was updated to new version of PHP 5.4.3-1. Before this, my app doesn´t work properly.

On this version of PHP, the model name has the first letter capitalized and won´t be load properly. This causes a FATAL ERROR.

The discussion at StackOverflow
http://stackoverflow.com/questions/10911296/fatal-error-class-category-not-found-after-php-version-upgrade
