### PR TITLE
Fixed problem with postgresql adapter

### DIFF
--- a/libraries/PHPActiveRecord.php
+++ b/libraries/PHPActiveRecord.php
@@ -35,8 +35,10 @@ class PHPActiveRecord {
         {
             foreach ($db as $conn_name => $conn)
             {
+                // in the case of the postgre driver, a conversion is needed
+                $dbdriver = $conn['dbdriver'] == 'postgre' ? 'pgsql' : $conn['dbdriver']; 
                 // Build the DSN string for each connection
-                $connections[$conn_name] =       $conn['dbdriver'].
+                $connections[$conn_name] =       $dbdriver.
                                     '://'       .$conn['username'].
                                     ':'         .$conn['password'].
                                     '@'         .$conn['hostname'].


### PR DESCRIPTION
Currently there is a bug with the postgresql adapter and it won't work. I have made it to work by changing the library file of the spark to get correct the name of the adaptor that has to be called
