### PR TITLE
Update Relationship.php

### DIFF
--- a/vendor/php-activerecord/lib/Relationship.php
+++ b/vendor/php-activerecord/lib/Relationship.php
@@ -464,13 +464,13 @@ class HasMany extends AbstractRelationship
 			$this->set_inferred_class_name();
 	}
 
-	protected function set_keys($model_class_name, $override=false)
+	protected function set_keys($model_class_name, $through=false)
 	{
-		//infer from class_name
-		if (!$this->foreign_key || $override)
-			$this->foreign_key = array(Inflector::instance()->keyify($model_class_name));
+		//If "through", get foreign key from the "through" relationship
+		if (!$this->foreign_key || $through)
+			$this->foreign_key = $this->get_Foreign_key_through($model_class_name);
 
-		if (!$this->primary_key || $override)
+		if (!$this->primary_key || $through)
 			$this->primary_key = Table::load($model_class_name)->pk;
 	}
 
@@ -547,6 +547,11 @@ class HasMany extends AbstractRelationship
 	{
 		$this->set_keys($table->class->name);
 		$this->query_and_attach_related_models_eagerly($table,$models,$attributes,$includes,$this->foreign_key, $table->pk);
+	}
+
+	private function get_Foreign_key_through($model_class_name){
+		$relation = $model_class_name::table()->get_relationship($this->through);
+		return $relation->foreign_key;
 	}
 };
 

--- a/vendor/php-activerecord/lib/Relationship.php
+++ b/vendor/php-activerecord/lib/Relationship.php
@@ -551,7 +551,10 @@ class HasMany extends AbstractRelationship
 
 	private function get_Foreign_key_through($model_class_name){
 		$relation = $model_class_name::table()->get_relationship($this->through);
-		return $relation->foreign_key;
+		$foreign_key = $relation->foreign_key;
+		if ($foreign_key==null)
+			$foreign_key = array(Inflector::instance()->keyify($model_class_name));
+		return $foreign_key;
 	}
 };
 


### PR DESCRIPTION
In a "has many through" relationship, the foreign key is obtained from the option "foreign key" of the relationship in the related model tha have the same name of the "through" option.
ES:
Table A=(id, x), PK=id
Table B=(id,y), PD=id
Table C=(id,idA,idB) PK=id FK=(idA->A.id, idB->B.id)

class A extends ActiveRecord\Model {
    static $has_many = array(
        array('aliasB', 'class_name' => 'B', 'through' => 'aliasC', 'foreign_key' => 'idA')
    );
}

class B extends ActiveRecord\Model{
    static $has_many = array(
        array('aliasC', 'class_name' => 'C', 'foreign_key' => 'idB'),
    );  
}

class C extends ActiveRecord\Model {
    static $belongs_to = array(
        array('aliasA', 'class_name' => 'A', 'foreign_key' => 'idA'),
        array('aliasB', 'class_name' => 'B', 'foreign_key' => 'idB')
    );
}

"A" has many "B" through "C": the foreign key between "B" and "C" is the foreing key of the "has many" array of "C" witch is named like the "through" option of che "has many through" relationship of "A".
